### PR TITLE
Deploy to subfolder

### DIFF
--- a/python-wheel.cmake
+++ b/python-wheel.cmake
@@ -67,14 +67,14 @@ function (add_wheel WHEEL_TARGET)
 
   # Set up wheel build dir
   set(WHEEL_NAME "${WHEEL_TARGET}")
-  set(WHEEL_LIB_DIR "${CMAKE_CURRENT_BINARY_DIR}/${WHEEL_NAME}.wheel/")
-  set(PACKAGE_DIR "${WHEEL_LIB_DIR}/${WHEEL_NAME}")
+  set(WHEEL_LIB_DIR "${CMAKE_CURRENT_BINARY_DIR}/${WHEEL_NAME}.wheel")
+  set(WHEEL_PACKAGE_DIR "${WHEEL_LIB_DIR}/${WHEEL_NAME}")
 
   # Create the package directory and __init__.py
   file(REMOVE_RECURSE "${WHEEL_LIB_DIR}")
   file(MAKE_DIRECTORY "${WHEEL_LIB_DIR}")
-  file(MAKE_DIRECTORY "${PACKAGE_DIR}")
-  file(WRITE "${PACKAGE_DIR}/__init__.py" "")
+  file(MAKE_DIRECTORY "${WHEEL_PACKAGE_DIR}")
+  file(WRITE "${WHEEL_PACKAGE_DIR}/__init__.py" "")
 
   # Only one wheel allowed per project.
   file(GLOB LOCAL_WHEEL_LIST "${CMAKE_CURRENT_BINARY_DIR}/*.wheel")

--- a/python-wheel.cmake
+++ b/python-wheel.cmake
@@ -87,14 +87,14 @@ function (add_wheel WHEEL_TARGET)
 
   # Copy module + dependencies into build dir
   add_custom_target(${WHEEL_TARGET}-copy-files)
-  _copy_target(${WHEEL_TARGET}-copy-files ${WHEEL_TARGET} "${WHEEL_LIB_DIR}")
+  _copy_target(${WHEEL_TARGET}-copy-files ${WHEEL_TARGET} "${WHEEL_PACKAGE_DIR}")
   add_dependencies(${WHEEL_TARGET}-copy-files ${WHEEL_TARGET})
 
   foreach (dep IN LISTS WHEEL_TARGET_DEPENDENCIES)
     if (TARGET ${dep})
       add_dependencies(${WHEEL_TARGET} ${dep})
 
-      _copy_target(${WHEEL_TARGET}-copy-files ${dep} ${WHEEL_LIB_DIR})
+      _copy_target(${WHEEL_TARGET}-copy-files ${dep} ${WHEEL_PACKAGE_DIR})
     else()
       message(FATAL_ERROR "Not a target ${dep}")
     endif()
@@ -102,20 +102,20 @@ function (add_wheel WHEEL_TARGET)
 
   if (WHEEL_LICENSE_PATH)
     add_custom_command(TARGET ${WHEEL_TARGET}-copy-files
-      COMMAND ${CMAKE_COMMAND} -E copy "${WHEEL_LICENSE_PATH}" "${WHEEL_LIB_DIR}/LICENSE.txt")
+      COMMAND ${CMAKE_COMMAND} -E copy "${WHEEL_LICENSE_PATH}" "${WHEEL_PACKAGE_DIR}/LICENSE.txt")
   endif()
 
   if (WHEEL_README_PATH)
     add_custom_command(TARGET ${WHEEL_TARGET}-copy-files
-      COMMAND ${CMAKE_COMMAND} -E copy "${WHEEL_README_PATH}" "${WHEEL_LIB_DIR}/README.txt")
+      COMMAND ${CMAKE_COMMAND} -E copy "${WHEEL_README_PATH}" "${WHEEL_PACKAGE_DIR}/README.txt")
   endif()
 
   if (WHEEL_DEPLOY_FILES)
     foreach (file IN LISTS WHEEL_DEPLOY_FILES)
       add_custom_command(TARGET ${WHEEL_TARGET}-copy-files
         POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E echo "Copying file from ${file} to ${WHEEL_LIB_DIR}"
-        COMMAND ${CMAKE_COMMAND} -E copy "${file}" "${WHEEL_LIB_DIR}/")
+        COMMAND ${CMAKE_COMMAND} -E echo "Copying file from ${file} to ${WHEEL_PACKAGE_DIR}"
+        COMMAND ${CMAKE_COMMAND} -E copy "${file}" "${WHEEL_PACKAGE_DIR}/")
     endforeach()
   endif()
 

--- a/python-wheel.cmake
+++ b/python-wheel.cmake
@@ -74,7 +74,7 @@ function (add_wheel WHEEL_TARGET)
   file(REMOVE_RECURSE "${WHEEL_LIB_DIR}")
   file(MAKE_DIRECTORY "${WHEEL_LIB_DIR}")
   file(MAKE_DIRECTORY "${WHEEL_PACKAGE_DIR}")
-  file(WRITE "${WHEEL_PACKAGE_DIR}/__init__.py" "")
+  file(WRITE "${WHEEL_PACKAGE_DIR}/__init__.py" "from .${WHEEL_NAME} import *")
 
   # Only one wheel allowed per project.
   file(GLOB LOCAL_WHEEL_LIST "${CMAKE_CURRENT_BINARY_DIR}/*.wheel")

--- a/python-wheel.cmake
+++ b/python-wheel.cmake
@@ -68,8 +68,13 @@ function (add_wheel WHEEL_TARGET)
   # Set up wheel build dir
   set(WHEEL_NAME "${WHEEL_TARGET}")
   set(WHEEL_LIB_DIR "${CMAKE_CURRENT_BINARY_DIR}/${WHEEL_NAME}.wheel/")
+  set(PACKAGE_DIR "${WHEEL_LIB_DIR}/${WHEEL_NAME}")
+
+  # Create the package directory and __init__.py
   file(REMOVE_RECURSE "${WHEEL_LIB_DIR}")
   file(MAKE_DIRECTORY "${WHEEL_LIB_DIR}")
+  file(MAKE_DIRECTORY "${PACKAGE_DIR}")
+  file(WRITE "${PACKAGE_DIR}/__init__.py" "")
 
   # Only one wheel allowed per project.
   file(GLOB LOCAL_WHEEL_LIST "${CMAKE_CURRENT_BINARY_DIR}/*.wheel")

--- a/setup.py.in
+++ b/setup.py.in
@@ -68,6 +68,7 @@ setup(
     install_requires = [
         @WHEEL_MODULE_DEPENDENCIES_PYLIST@
     ],
+    package_dir = {"": "@WHEEL_LIB_DIR@"},
     packages = ["@WHEEL_NAME@"],
     package_data = {
         "@WHEEL_NAME@": ["*"]

--- a/setup.py.in
+++ b/setup.py.in
@@ -23,7 +23,7 @@ class CMakeExtension(Extension):
 class cmake_build_ext(build_ext):
     def run(self):
         self.build_temp = '@CMAKE_BINARY_DIR@'
-        self.build_lib = '@WHEEL_LIB_DIR@'
+        self.build_lib = '@WHEEL_PACKAGE_DIR@'
         if platform.system() == 'Linux':
             self.fix_linux_loader_paths()
         self.copy_extensions_to_source()

--- a/setup.py.in
+++ b/setup.py.in
@@ -68,6 +68,10 @@ setup(
     install_requires = [
         @WHEEL_MODULE_DEPENDENCIES_PYLIST@
     ],
+    packages = ["@WHEEL_NAME@"],
+    package_data = {
+        "@WHEEL_NAME@": ["*"]
+    },
 
     cmdclass = {
         'bdist': bdist,

--- a/setup.py.in
+++ b/setup.py.in
@@ -29,9 +29,9 @@ class cmake_build_ext(build_ext):
         self.copy_extensions_to_source()
 
     def fix_linux_loader_paths(self):
-        for f in os.listdir('@WHEEL_LIB_DIR@'):
+        for f in os.listdir('@WHEEL_PACKAGE_DIR@'):
             print(f"cmake_build_ext: Fixing {f}")
-            file_path = os.path.join('@WHEEL_LIB_DIR@', f)
+            file_path = os.path.join('@WHEEL_PACKAGE_DIR@', f)
             if f.endswith('.so'):
                 self.spawn(['patchelf', '--set-rpath', '$ORIGIN', file_path])
 
@@ -68,7 +68,7 @@ setup(
     install_requires = [
         @WHEEL_MODULE_DEPENDENCIES_PYLIST@
     ],
-    package_dir = {"": "@WHEEL_LIB_DIR@"},
+    package_dir = {"": "@WHEEL_NAME@.wheel"},
     packages = ["@WHEEL_NAME@"],
     package_data = {
         "@WHEEL_NAME@": ["*"]


### PR DESCRIPTION
This allows specifying __main__ and other Python modules in addition to the binary module via DEPLOY_FILES.
