### PR TITLE
Use CMake's internal RPATH setting

### DIFF
--- a/python-wheel.cmake
+++ b/python-wheel.cmake
@@ -180,6 +180,11 @@ function (add_wheel WHEEL_TARGET)
   add_dependencies(${WHEEL_TARGET}-setup-py ${WHEEL_TARGET}-copy-files ${WHEEL_TARGET})
 
   add_dependencies(wheel ${WHEEL_TARGET}-setup-py)
+
+  set_target_properties(${WHEEL_TARGET} PROPERTIES
+    BUILD_RPATH "\$ORIGIN;" # Override hardcoded RPATH
+    INSTALL_RPATH "\$ORIGIN;"
+  )
 endfunction()
 
 function (add_wheel_test TEST_NAME)

--- a/setup.py.in
+++ b/setup.py.in
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import os, sys, platform, stat
+import os, sys, stat
 import zipfile
 import subprocess
 import re
@@ -26,16 +26,6 @@ class cmake_build_ext(build_ext):
     def run(self):
         self.build_temp = '@CMAKE_BINARY_DIR@'
         self.build_lib = '@WHEEL_PACKAGE_DIR@'
-        if platform.system() == 'Linux':
-            self.fix_linux_loader_paths()
-
-    def fix_linux_loader_paths(self):
-        for f in os.listdir('@WHEEL_PACKAGE_DIR@'):
-            print(f"cmake_build_ext: Fixing {f}")
-            file_path = os.path.join('@WHEEL_PACKAGE_DIR@', f)
-            if f.endswith('.so'):
-                self.spawn(['patchelf', '--set-rpath', '$ORIGIN', file_path])
-
 
 class bdist(_bdist):
     def finalize_options(self):


### PR DESCRIPTION
Usually when a binary is built CMake links external libraries with a hardcoded path until `cmake install` is called. At that point CMake switches RPATH to be more generic. You may read more at the [dedicated help page](https://cmake.org/cmake/help/latest/prop_tgt/BUILD_RPATH.html).
Let me know if I missed any detail.

Cheers!