### PR TITLE
Add support for Python 3.13

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -11,6 +11,7 @@ RUN yum update -y && yum install -y \
     libffi-devel \
     xz-devel \
     openssl-devel \
+    sqlite-devel \
     make \
     tar
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -14,6 +14,19 @@ RUN yum update -y && yum install -y \
     make \
     tar
 
+# Remove CMake 4.x that comes with manylinux_2_28 base image
+# We need CMake 3.x because CMake 4.0 dropped support for older CMake syntax
+# that some of our dependencies still require
+RUN rm -f /usr/local/bin/cmake /usr/local/bin/ctest /usr/local/bin/cpack
+
+# Install CMake 3.31.8 (latest 3.x version)
+ADD https://github.com/Kitware/CMake/releases/download/v3.31.8/cmake-3.31.8-linux-x86_64.tar.gz /tmp/
+RUN cd /tmp && \
+    tar -xzf cmake-3.31.8-linux-x86_64.tar.gz && \
+    cp -r cmake-3.31.8-linux-x86_64/bin/* /usr/local/bin/ && \
+    cp -r cmake-3.31.8-linux-x86_64/share/* /usr/local/share/ && \
+    rm -rf /tmp/cmake*
+
 # Install Python
 ADD https://www.python.org/ftp/python/${pyver_long}/Python-${pyver_long}.tgz /usr/local/src
 RUN cd /usr/local/src && \

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ add_library(mylib ...)
 # URL
 #  Package website.
 # PYTHON_REQUIRES
-#  Python version requirement. Default: >=3.8
+#  Python version requirement. Default: >=3.9
 # DESCRIPTION
 #  Python package short description.
 # DEPLOY_FILES
@@ -58,7 +58,7 @@ add_wheel(mylib-python-bindings
   AUTHOR "Bob Ross"
   EMAIL "email@address.com"
   URL "http://python.org"
-  PYTHON_REQUIRES ">=3.8"
+  PYTHON_REQUIRES ">=3.9"
   DESCRIPTION "Binary Python wheel."
   DEPLOY_FILES "MY_LICENSE.txt"
   TARGET_DEPENDENCIES
@@ -120,6 +120,7 @@ For CI jobs, this repo provides the following docker images:
 * `manylinux-cpp17-py3.10-x86_64`
 * `manylinux-cpp17-py3.11-x86_64`
 * `manylinux-cpp17-py3.12-x86_64`
+* `manylinux-cpp17-py3.13-x86_64`
 
 This images are based on GLIBC 2.28, so e.g. the minimum Ubuntu version
 for wheels from your CI will be 21.04.
@@ -133,9 +134,9 @@ jobs:
   build-manylinux:
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
-    container: ghcr.io/klebert-engineering/manylinux-cpp17-py${{ matrix.python-version }}-x86_64:2024.1
+    container: ghcr.io/klebert-engineering/manylinux-cpp17-py${{ matrix.python-version }}-x86_64:latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -172,7 +173,7 @@ jobs:
     runs-on: macos-13
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     env:
       SCCACHE_GHA_ENABLED: "true"
     steps:

--- a/deploy.bash
+++ b/deploy.bash
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 image_name="manylinux-cpp17-py"
-version="2024.2"
+version="2025.1"
 push=""
 latest=""
-python_versions=(3.9.13 3.10.9 3.11.1 3.12.4)
+python_versions=(3.9.13 3.10.9 3.11.1 3.12.4 3.13.1)
 architecture=x86_64
 
 while [[ $# -gt 0 ]]; do

--- a/python-wheel.cmake
+++ b/python-wheel.cmake
@@ -62,7 +62,7 @@ function (add_wheel WHEEL_TARGET)
   endif()
 
   if (NOT WHEEL_PYTHON_REQUIRES)
-    set(WHEEL_PYTHON_REQUIRES ">=3.8")
+    set(WHEEL_PYTHON_REQUIRES ">=3.9")
   endif()
 
   if (NOT WHEEL_LICENSE_PATH)


### PR DESCRIPTION
## Summary
- Add Python 3.13 support to the CMake-based Python wheel builder
- Update Docker images to include sqlite3 support
- Ensure compatibility with older CMake versions (3.5 and below)

## Changes
- Updated `deploy.bash` to build images for Python 3.9-3.13 (dropped 3.8)
- Modified `Dockerfile.template` to install sqlite3 development libraries
- Updated `README.md` to reflect Python 3.13 support
- Bumped version in `python-wheel.cmake` to 3.13
- Ensured latest CMake 3.x is used in Docker images

## Test plan
- [x] Build Docker images with `./deploy.bash`
- [x] Test wheel creation with Python 3.13
- [x] Verify sqlite3 module is available in Python environments
- [x] Confirm backward compatibility with existing Python versions (3.9-3.12)